### PR TITLE
ci: separate esbuild from renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,6 +6,11 @@
       "matchManagers": ["npm"],
       "matchPackageNames": ["constructs", "aws-cdk-lib"],
       "enabled": false
+    },
+    {
+      "groupName": "esbuild",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["esbuild"]
     }
   ],
   "baseBranches": ["develop"]


### PR DESCRIPTION
The version of esbuild affects the Lambda bundle results and leads to redeployment of Lambda.