### PR TITLE
ci: separate aws-sdk from renovate group

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,11 @@
       "groupName": "esbuild",
       "matchManagers": ["npm"],
       "matchPackageNames": ["esbuild"]
+    },
+    {
+      "groupName": "@aws-sdk/client-ec2",
+      "matchManagers": ["npm"],
+      "matchPackageNames": ["@aws-sdk/client-ec2"]
     }
   ],
   "baseBranches": ["develop"]


### PR DESCRIPTION
The version of aws SDK affects the Lambda bundle results and leads to redeployment of Lambda.